### PR TITLE
Harden auth config, cookies, and CORS policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Sentinent Backend
+
+## Required Environment Variables
+
+Set these before running the server:
+
+- `JWT_SECRET`: HMAC secret used to sign and verify JWT tokens.
+- `CORS_ALLOWED_ORIGINS`: Comma-separated list of allowed browser origins.
+
+Optional:
+
+- `APP_ENV`: Set to `production` (or `prod`) to enable `Secure` auth cookies.
+
+## Example (local development)
+
+```powershell
+$env:JWT_SECRET = "replace-with-a-long-random-secret"
+$env:CORS_ALLOWED_ORIGINS = "http://localhost:4200"
+$env:APP_ENV = "development"
+go run .
+```

--- a/main.go
+++ b/main.go
@@ -3,12 +3,28 @@ package main
 import (
 	"log"
 	"net/http"
+	"os"
 	"sentinent-backend/database"
 	"sentinent-backend/handlers"
 	"sentinent-backend/middleware"
+	"strings"
 )
 
 func main() {
+	jwtSecret := strings.TrimSpace(os.Getenv("JWT_SECRET"))
+	if jwtSecret == "" {
+		log.Fatal("JWT_SECRET is required")
+	}
+	handlers.JwtKey = []byte(jwtSecret)
+
+	corsAllowedOrigins := strings.TrimSpace(os.Getenv("CORS_ALLOWED_ORIGINS"))
+	if corsAllowedOrigins == "" {
+		log.Fatal("CORS_ALLOWED_ORIGINS is required (comma-separated origins)")
+	}
+	if err := middleware.SetAllowedOrigins(strings.Split(corsAllowedOrigins, ",")); err != nil {
+		log.Fatalf("invalid CORS_ALLOWED_ORIGINS: %v", err)
+	}
+
 	database.InitDB()
 
 	// Create a new ServeMux for our application routes

--- a/middleware/cors.go
+++ b/middleware/cors.go
@@ -1,21 +1,106 @@
 package middleware
 
 import (
+	"fmt"
 	"net/http"
+	"net/url"
+	"strings"
 )
+
+var allowedOrigins = map[string]struct{}{}
+
+func SetAllowedOrigins(origins []string) error {
+	normalizedOrigins := make(map[string]struct{}, len(origins))
+
+	for _, origin := range origins {
+		if strings.TrimSpace(origin) == "" {
+			continue
+		}
+		normalizedOrigin, err := normalizeOrigin(origin)
+		if err != nil {
+			return err
+		}
+		normalizedOrigins[normalizedOrigin] = struct{}{}
+	}
+
+	if len(normalizedOrigins) == 0 {
+		return fmt.Errorf("at least one valid CORS origin is required")
+	}
+
+	allowedOrigins = normalizedOrigins
+	return nil
+}
 
 func CorsMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
-		w.Header().Set("Access-Control-Allow-Credentials", "true")
+		origin := strings.TrimSpace(r.Header.Get("Origin"))
+		originAllowed := false
+		normalizedOrigin := ""
 
-		if r.Method == "OPTIONS" {
-			w.WriteHeader(http.StatusOK)
+		if origin != "" {
+			var err error
+			normalizedOrigin, err = normalizeOrigin(origin)
+			if err == nil {
+				_, originAllowed = allowedOrigins[normalizedOrigin]
+			}
+
+			if originAllowed {
+				setCORSHeaders(w, normalizedOrigin)
+			} else if r.Method == http.MethodOptions {
+				http.Error(w, "CORS origin denied", http.StatusForbidden)
+				return
+			}
+		}
+
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
 			return
 		}
 
 		next.ServeHTTP(w, r)
 	})
+}
+
+func setCORSHeaders(w http.ResponseWriter, origin string) {
+	addVaryHeader(w, "Origin")
+	addVaryHeader(w, "Access-Control-Request-Method")
+	addVaryHeader(w, "Access-Control-Request-Headers")
+	w.Header().Set("Access-Control-Allow-Origin", origin)
+	w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+	w.Header().Set("Access-Control-Allow-Credentials", "true")
+}
+
+func addVaryHeader(w http.ResponseWriter, value string) {
+	for _, existing := range w.Header().Values("Vary") {
+		for _, part := range strings.Split(existing, ",") {
+			if strings.EqualFold(strings.TrimSpace(part), value) {
+				return
+			}
+		}
+	}
+	w.Header().Add("Vary", value)
+}
+
+func normalizeOrigin(origin string) (string, error) {
+	trimmedOrigin := strings.TrimSpace(origin)
+	if trimmedOrigin == "" {
+		return "", fmt.Errorf("empty CORS origin")
+	}
+
+	parsed, err := url.Parse(trimmedOrigin)
+	if err != nil {
+		return "", fmt.Errorf("invalid CORS origin %q: %w", trimmedOrigin, err)
+	}
+	if parsed.Scheme == "" || parsed.Host == "" {
+		return "", fmt.Errorf("invalid CORS origin %q", trimmedOrigin)
+	}
+	if parsed.Path != "" && parsed.Path != "/" {
+		return "", fmt.Errorf("CORS origin must not contain a path: %q", trimmedOrigin)
+	}
+	if parsed.RawQuery != "" || parsed.Fragment != "" || parsed.User != nil {
+		return "", fmt.Errorf("CORS origin must only include scheme and host: %q", trimmedOrigin)
+	}
+
+	return strings.ToLower(parsed.Scheme) + "://" + strings.ToLower(parsed.Host), nil
 }

--- a/middleware/cors_test.go
+++ b/middleware/cors_test.go
@@ -1,0 +1,92 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func testCORSHandler(t *testing.T, origins ...string) http.Handler {
+	t.Helper()
+	if err := SetAllowedOrigins(origins); err != nil {
+		t.Fatalf("failed to configure allowed origins: %v", err)
+	}
+
+	return CorsMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+}
+
+func TestCorsMiddlewareAllowsConfiguredOrigin(t *testing.T) {
+	handler := testCORSHandler(t, "http://localhost:4200")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/protected", nil)
+	req.Header.Set("Origin", "http://localhost:4200")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rr.Code)
+	}
+	if got := rr.Header().Get("Access-Control-Allow-Origin"); got != "http://localhost:4200" {
+		t.Fatalf("expected allowed origin header, got %q", got)
+	}
+	if got := rr.Header().Get("Access-Control-Allow-Credentials"); got != "true" {
+		t.Fatalf("expected credentials header true, got %q", got)
+	}
+}
+
+func TestCorsMiddlewareDoesNotSetHeadersForDisallowedOrigin(t *testing.T) {
+	handler := testCORSHandler(t, "http://localhost:4200")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/protected", nil)
+	req.Header.Set("Origin", "http://evil.example")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rr.Code)
+	}
+	if got := rr.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Fatalf("expected no allow-origin header for disallowed origin, got %q", got)
+	}
+}
+
+func TestCorsMiddlewareRejectsDisallowedPreflight(t *testing.T) {
+	handler := testCORSHandler(t, "http://localhost:4200")
+
+	req := httptest.NewRequest(http.MethodOptions, "/api/protected", nil)
+	req.Header.Set("Origin", "http://evil.example")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("expected status 403, got %d", rr.Code)
+	}
+}
+
+func TestCorsMiddlewareHandlesAllowedPreflight(t *testing.T) {
+	handler := testCORSHandler(t, "http://localhost:4200")
+
+	req := httptest.NewRequest(http.MethodOptions, "/api/protected", nil)
+	req.Header.Set("Origin", "http://localhost:4200")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("expected status 204, got %d", rr.Code)
+	}
+	if got := rr.Header().Get("Access-Control-Allow-Origin"); got != "http://localhost:4200" {
+		t.Fatalf("expected allowed origin header, got %q", got)
+	}
+}
+
+func TestSetAllowedOriginsRejectsInvalidOrigin(t *testing.T) {
+	if err := SetAllowedOrigins([]string{"not-an-origin"}); err == nil {
+		t.Fatalf("expected invalid origin error")
+	}
+}


### PR DESCRIPTION
## Summary
This PR hardens backend authentication and cross-origin security configuration by removing hardcoded JWT secrets, enforcing secure cookie defaults, and replacing permissive CORS with an explicit origin allowlist.

## What Changed
- Added startup config validation in `backend-go/main.go`:
  - Requires `JWT_SECRET`
  - Requires `CORS_ALLOWED_ORIGINS` (comma-separated)
- Updated JWT signing flow in `backend-go/handlers/auth.go`:
  - Removed hardcoded secret dependency
  - Added fail-safe response if JWT secret is not configured
- Hardened auth cookie in `backend-go/handlers/auth.go`:
  - `HttpOnly: true`
  - `SameSite: Lax`
  - `Path: /`
  - `Secure: true` when `APP_ENV=production|prod`
- Reworked CORS middleware in `backend-go/middleware/cors.go`:
  - Validates and stores allowed origins
  - Echoes only matched origins (no wildcard)
  - Adds proper `Vary` headers for cache correctness
  - Rejects disallowed preflight requests with `403`
  - Returns `204` for valid preflight requests
- Added tests:
  - `backend-go/middleware/cors_test.go`
  - `backend-go/handlers/auth_test.go` (cookie security assertions)
- Added backend env documentation:
  - `backend-go/README.md`

## Why
- Avoids secret leakage from source control by moving JWT secret to env config.
- Reduces XSS/CSRF/session theft risk with hardened cookie attributes.
- Fixes invalid/unsafe CORS pattern (`*` + credentials) and enforces explicit browser origins.