### PR TITLE
feat: implement robust email validation for signup and signin

### DIFF
--- a/handlers/auth.go
+++ b/handlers/auth.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"sentinent-backend/database"
 	"sentinent-backend/models"
+	"sentinent-backend/utils"
 	"strings"
 	"time"
 
@@ -21,6 +22,11 @@ func Signup(w http.ResponseWriter, r *http.Request) {
 	err := json.NewDecoder(r.Body).Decode(&user)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	if !utils.IsEmailValid(user.Email) {
+		http.Error(w, "Invalid email format", http.StatusBadRequest)
 		return
 	}
 
@@ -44,6 +50,11 @@ func Signin(w http.ResponseWriter, r *http.Request) {
 	err := json.NewDecoder(r.Body).Decode(&creds)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	if !utils.IsEmailValid(creds.Email) {
+		http.Error(w, "Invalid email format", http.StatusBadRequest)
 		return
 	}
 

--- a/handlers/auth_test.go
+++ b/handlers/auth_test.go
@@ -142,3 +142,45 @@ func TestSigninCookieSecureInProduction(t *testing.T) {
 		t.Errorf("expected token cookie Secure=true in production mode")
 	}
 }
+
+func TestSignupInvalidEmail(t *testing.T) {
+	setupTestDB()
+	defer database.DB.Close()
+
+	user := models.User{
+		Email:    "invalid-email",
+		Password: "password123",
+	}
+	body, _ := json.Marshal(user)
+
+	req, _ := http.NewRequest("POST", "/signup", bytes.NewBuffer(body))
+	rr := httptest.NewRecorder()
+
+	Signup(rr, req)
+
+	if status := rr.Code; status != http.StatusBadRequest {
+		t.Errorf("handler returned wrong status code: got %v want %v",
+			status, http.StatusBadRequest)
+	}
+}
+
+func TestSigninInvalidEmail(t *testing.T) {
+	setupTestDB()
+	defer database.DB.Close()
+
+	user := models.User{
+		Email:    "invalid-email",
+		Password: "password123",
+	}
+	body, _ := json.Marshal(user)
+
+	req, _ := http.NewRequest("POST", "/signin", bytes.NewBuffer(body))
+	rr := httptest.NewRecorder()
+
+	Signin(rr, req)
+
+	if status := rr.Code; status != http.StatusBadRequest {
+		t.Errorf("handler returned wrong status code: got %v want %v",
+			status, http.StatusBadRequest)
+	}
+}

--- a/utils/validation.go
+++ b/utils/validation.go
@@ -1,0 +1,10 @@
+package utils
+
+import (
+	"regexp"
+)
+
+func IsEmailValid(e string) bool {
+	emailRegex := regexp.MustCompile(`^[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}$`)
+	return emailRegex.MatchString(e)
+}

--- a/utils/validation_test.go
+++ b/utils/validation_test.go
@@ -1,0 +1,27 @@
+package utils
+
+import "testing"
+
+func TestIsEmailValid(t *testing.T) {
+	tests := []struct {
+		email    string
+		expected bool
+	}{
+		{"test@example.com", true},
+		{"TEST@example.com", true},      // Current one might fail this
+		{"test@example.museum", true},   // Current one might fail this (TLD length > 4)
+		{"test@sub.example.com", true},
+		{"invalid-email", false},
+		{"@example.com", false},
+		{"test@", false},
+		{"test@example", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.email, func(t *testing.T) {
+			if got := IsEmailValid(tt.email); got != tt.expected {
+				t.Errorf("IsEmailValid(%q) = %v; want %v", tt.email, got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR introduces a more comprehensive email validation regex in utils/validation.go, supporting case-sensitivity and modern top-level domains. It also adds validation checks to both Signup and Signin handlers, along with corresponding unit tests.