### PR TITLE
fix: unify signal status resolution

### DIFF
--- a/handlers/signals.go
+++ b/handlers/signals.go
@@ -126,10 +126,27 @@ func GetSignals(w http.ResponseWriter, r *http.Request) {
 	// Get total count
 	countQuery := "SELECT COUNT(*) FROM signals WHERE workspace_id = ? AND user_id = ?"
 	countArgs := []interface{}{workspaceID, userID}
+	if filter.Status != "" {
+		countQuery = `
+			SELECT COUNT(*)
+			FROM signals s
+			LEFT JOIN signal_status ss ON s.id = ss.signal_id AND ss.user_id = ?
+			WHERE s.workspace_id = ? AND s.user_id = ?`
+		countArgs = []interface{}{userID, workspaceID, userID}
+	}
 
 	if filter.SourceType != "" {
-		countQuery += " AND source_type = ?"
+		if filter.Status != "" {
+			countQuery += " AND s.source_type = ?"
+		} else {
+			countQuery += " AND source_type = ?"
+		}
 		countArgs = append(countArgs, filter.SourceType)
+	}
+
+	if filter.Status != "" {
+		countQuery += " AND COALESCE(ss.status, s.status) = ?"
+		countArgs = append(countArgs, filter.Status)
 	}
 
 	var total int

--- a/handlers/signals_test.go
+++ b/handlers/signals_test.go
@@ -1,0 +1,153 @@
+package handlers
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sentinent-backend/database"
+	"sentinent-backend/middleware"
+	"sentinent-backend/models"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func setupSignalsTestDB(t *testing.T) {
+	t.Helper()
+
+	var err error
+	database.DB, err = sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("failed to open test db: %v", err)
+	}
+
+	statements := []string{
+		`CREATE TABLE users (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			email TEXT NOT NULL UNIQUE,
+			password TEXT NOT NULL
+		);`,
+		`CREATE TABLE signals (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			user_id INTEGER NOT NULL,
+			workspace_id INTEGER,
+			source_type TEXT NOT NULL,
+			source_id TEXT NOT NULL,
+			external_id TEXT,
+			title TEXT NOT NULL,
+			content TEXT,
+			author TEXT,
+			body TEXT,
+			url TEXT,
+			status TEXT DEFAULT 'unread',
+			source_metadata TEXT,
+			received_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+		);`,
+		`CREATE TABLE signal_status (
+			signal_id INTEGER NOT NULL,
+			user_id INTEGER NOT NULL,
+			status TEXT NOT NULL,
+			updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			PRIMARY KEY (signal_id, user_id)
+		);`,
+	}
+
+	for _, statement := range statements {
+		if _, err := database.DB.Exec(statement); err != nil {
+			t.Fatalf("failed to prepare test schema: %v", err)
+		}
+	}
+
+	if _, err := database.DB.Exec(
+		`INSERT INTO users (id, email, password) VALUES (1, 'reader@example.com', 'hashed-password')`,
+	); err != nil {
+		t.Fatalf("failed to seed user: %v", err)
+	}
+
+	if _, err := database.DB.Exec(
+		`INSERT INTO signals
+			(id, user_id, workspace_id, source_type, source_id, external_id, title, content, status)
+		 VALUES
+			(1, 1, 7, 'github', 'sig-1', 'external-1', 'Signal One', 'Body', 'unread'),
+			(2, 1, 7, 'github', 'sig-2', 'external-2', 'Signal Two', 'Body', 'unread')`,
+	); err != nil {
+		t.Fatalf("failed to seed signals: %v", err)
+	}
+
+	if _, err := database.DB.Exec(
+		`INSERT INTO signal_status (signal_id, user_id, status) VALUES (1, 1, ?)`,
+		models.SignalStatusRead,
+	); err != nil {
+		t.Fatalf("failed to seed signal status: %v", err)
+	}
+}
+
+func signalRequestWithUser(method, target string) *http.Request {
+	req := httptest.NewRequest(method, target, nil)
+	return req.WithContext(context.WithValue(req.Context(), middleware.UserEmailKey, "reader@example.com"))
+}
+
+func TestSignalsHandlerUsesResolvedSignalStatus(t *testing.T) {
+	setupSignalsTestDB(t)
+	defer database.DB.Close()
+
+	req := signalRequestWithUser(http.MethodGet, "/api/signals?status=read")
+	rr := httptest.NewRecorder()
+
+	SignalsHandler(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rr.Code)
+	}
+
+	var signals []models.Signal
+	if err := json.NewDecoder(rr.Body).Decode(&signals); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if len(signals) != 1 {
+		t.Fatalf("expected 1 signal, got %d", len(signals))
+	}
+	if signals[0].ID != 1 {
+		t.Fatalf("expected signal 1, got %d", signals[0].ID)
+	}
+	if signals[0].Status != models.SignalStatusRead {
+		t.Fatalf("expected resolved status %q, got %q", models.SignalStatusRead, signals[0].Status)
+	}
+}
+
+func TestWorkspaceSignalsStatusFilterUsesResolvedStatusForResultsAndTotal(t *testing.T) {
+	setupSignalsTestDB(t)
+	defer database.DB.Close()
+
+	req := signalRequestWithUser(http.MethodGet, "/api/workspaces/7/signals?status=read")
+	rr := httptest.NewRecorder()
+
+	GetSignals(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rr.Code)
+	}
+
+	var response models.SignalListResponse
+	if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if len(response.Signals) != 1 {
+		t.Fatalf("expected 1 signal, got %d", len(response.Signals))
+	}
+	if response.Total != 1 {
+		t.Fatalf("expected total 1, got %d", response.Total)
+	}
+	if response.Signals[0].ID != 1 {
+		t.Fatalf("expected signal 1, got %d", response.Signals[0].ID)
+	}
+	if response.Signals[0].Status != models.SignalStatusRead {
+		t.Fatalf("expected resolved status %q, got %q", models.SignalStatusRead, response.Signals[0].Status)
+	}
+}

--- a/services/github.go
+++ b/services/github.go
@@ -444,21 +444,25 @@ func saveGitHubSignal(userID int, issue GitHubIssue, issueType string) error {
 
 // GetUserSignals retrieves signals for a user with optional filtering
 func GetUserSignals(userID int, filter *models.SignalFilter) ([]models.Signal, error) {
-	query := `SELECT id, user_id, workspace_id, source_type, source_id, external_id, title, content, author, body, url, status, source_metadata, received_at, created_at, updated_at
-		FROM signals WHERE user_id = ?`
-	args := []interface{}{userID}
+	query := `SELECT s.id, s.user_id, s.workspace_id, s.source_type, s.source_id, s.external_id,
+		s.title, s.content, s.author, s.body, s.url, COALESCE(ss.status, s.status) as status,
+		s.source_metadata, s.received_at, s.created_at, s.updated_at
+		FROM signals s
+		LEFT JOIN signal_status ss ON s.id = ss.signal_id AND ss.user_id = ?
+		WHERE s.user_id = ?`
+	args := []interface{}{userID, userID}
 
 	if filter != nil && filter.SourceType != "" {
-		query += " AND source_type = ?"
+		query += " AND s.source_type = ?"
 		args = append(args, filter.SourceType)
 	}
 
 	if filter != nil && filter.Status != "" {
-		query += " AND status = ?"
+		query += " AND COALESCE(ss.status, s.status) = ?"
 		args = append(args, filter.Status)
 	}
 
-	query += " ORDER BY updated_at DESC"
+	query += " ORDER BY s.updated_at DESC"
 
 	rows, err := database.DB.Query(query, args...)
 	if err != nil {


### PR DESCRIPTION
## Summary
- resolve `/api/signals` status through `signal_status` the same way workspace signal reads do
- make workspace totals use the same effective status filter as workspace results
- add regression tests covering generic and workspace signal endpoints

## Testing
- Not run locally (`go` toolchain is not installed in this environment)