### PR TITLE
feat: add request logging middleware and debug logs

### DIFF
--- a/handlers/workspaces.go
+++ b/handlers/workspaces.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"database/sql"
 	"encoding/json"
+	"log"
 	"net/http"
 	"sentinent-backend/database"
 	"sentinent-backend/middleware"
@@ -154,6 +155,7 @@ func GetWorkspace(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	log.Printf("Successfully fetched workspace %d", workspaceID)
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(workspace)
 }

--- a/main.go
+++ b/main.go
@@ -112,9 +112,16 @@ func main() {
 	// Webhook routes (public, but should verify signature in production)
 	mux.HandleFunc("/api/webhooks/github", handlers.GitHubWebhookHandler)
 
-	// Apply CORS middleware to the entire mux
-	handler := middleware.CorsMiddleware(mux)
+	// Apply CORS and logging middleware
+	handler := loggingMiddleware(middleware.CorsMiddleware(mux))
 
 	log.Println("Server started on :8080")
 	log.Fatal(http.ListenAndServe(":8080", handler))
+}
+
+func loggingMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		log.Printf("%s %s %s", r.RemoteAddr, r.Method, r.URL.Path)
+		next.ServeHTTP(w, r)
+	})
 }


### PR DESCRIPTION
Closes Sentinent-AI/Sentinent#24.

This PR adds a simple request logging middleware to the backend to improve observability and help debug issues like the workspace loading hang.

### Changes:
- Added  to .
- Added a success log to  handler.