### PR TITLE
feat: support profile viewing and editing via backend APIs

### DIFF
--- a/database/db.go
+++ b/database/db.go
@@ -21,7 +21,13 @@ func InitDB() {
 		`CREATE TABLE IF NOT EXISTS users (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
 			email TEXT NOT NULL UNIQUE,
-			password TEXT NOT NULL
+			password TEXT NOT NULL,
+			full_name TEXT DEFAULT '',
+			job_title TEXT DEFAULT '',
+			organization TEXT DEFAULT '',
+			timezone TEXT DEFAULT '',
+			bio TEXT DEFAULT '',
+			role_label TEXT DEFAULT ''
 		);`,
 		`CREATE TABLE IF NOT EXISTS workspaces (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -153,6 +159,12 @@ func InitDB() {
 	ensureColumn("external_integrations", "metadata", "TEXT")
 
 	ensureColumn("workspaces", "description", "TEXT DEFAULT ''")
+	ensureColumn("users", "full_name", "TEXT DEFAULT ''")
+	ensureColumn("users", "job_title", "TEXT DEFAULT ''")
+	ensureColumn("users", "organization", "TEXT DEFAULT ''")
+	ensureColumn("users", "timezone", "TEXT DEFAULT ''")
+	ensureColumn("users", "bio", "TEXT DEFAULT ''")
+	ensureColumn("users", "role_label", "TEXT DEFAULT ''")
 
 	ensureColumn("signals", "workspace_id", "INTEGER")
 	ensureColumn("signals", "external_id", "TEXT")

--- a/handlers/auth.go
+++ b/handlers/auth.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"sentinent-backend/database"
+	"sentinent-backend/middleware"
 	"sentinent-backend/models"
 	"sentinent-backend/services"
 	"sentinent-backend/utils"
@@ -33,6 +34,15 @@ type resetPasswordRequest struct {
 	Password string `json:"password"`
 }
 
+type profileUpdateRequest struct {
+	FullName     string `json:"full_name"`
+	JobTitle     string `json:"job_title"`
+	Organization string `json:"organization"`
+	Timezone     string `json:"timezone"`
+	Bio          string `json:"bio"`
+	RoleLabel    string `json:"role_label"`
+}
+
 func Signup(w http.ResponseWriter, r *http.Request) {
 	var user models.User
 	err := json.NewDecoder(r.Body).Decode(&user)
@@ -46,13 +56,32 @@ func Signup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	user.Email = strings.TrimSpace(user.Email)
+	user.FullName = strings.TrimSpace(user.FullName)
+	user.JobTitle = strings.TrimSpace(user.JobTitle)
+	user.Organization = strings.TrimSpace(user.Organization)
+	user.Timezone = strings.TrimSpace(user.Timezone)
+	user.Bio = strings.TrimSpace(user.Bio)
+	user.RoleLabel = strings.TrimSpace(user.RoleLabel)
+
 	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(user.Password), bcrypt.DefaultCost)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	_, err = database.DB.Exec("INSERT INTO users (email, password) VALUES (?, ?)", user.Email, string(hashedPassword))
+	_, err = database.DB.Exec(
+		`INSERT INTO users (email, password, full_name, job_title, organization, timezone, bio, role_label)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		user.Email,
+		string(hashedPassword),
+		user.FullName,
+		user.JobTitle,
+		user.Organization,
+		user.Timezone,
+		user.Bio,
+		user.RoleLabel,
+	)
 	if err != nil {
 		http.Error(w, "Email already exists", http.StatusConflict)
 		return
@@ -310,6 +339,97 @@ func ResetPassword(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusNoContent)
+}
+
+func ProfileHandler(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		getProfile(w, r)
+	case http.MethodPatch:
+		updateProfile(w, r)
+	default:
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func getProfile(w http.ResponseWriter, r *http.Request) {
+	userID, ok := middleware.GetUserID(r.Context())
+	if !ok {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	var user models.User
+	err := database.DB.QueryRow(
+		`SELECT id, email, full_name, job_title, organization, timezone, bio, role_label
+		 FROM users WHERE id = ?`,
+		userID,
+	).Scan(
+		&user.ID,
+		&user.Email,
+		&user.FullName,
+		&user.JobTitle,
+		&user.Organization,
+		&user.Timezone,
+		&user.Bio,
+		&user.RoleLabel,
+	)
+	if err == sql.ErrNoRows {
+		http.Error(w, "User not found", http.StatusNotFound)
+		return
+	}
+	if err != nil {
+		http.Error(w, "Failed to load profile", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(user)
+}
+
+func updateProfile(w http.ResponseWriter, r *http.Request) {
+	userID, ok := middleware.GetUserID(r.Context())
+	if !ok {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	var req profileUpdateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	req.FullName = strings.TrimSpace(req.FullName)
+	req.JobTitle = strings.TrimSpace(req.JobTitle)
+	req.Organization = strings.TrimSpace(req.Organization)
+	req.Timezone = strings.TrimSpace(req.Timezone)
+	req.Bio = strings.TrimSpace(req.Bio)
+	req.RoleLabel = strings.TrimSpace(req.RoleLabel)
+
+	if req.FullName == "" {
+		http.Error(w, "Full name is required", http.StatusBadRequest)
+		return
+	}
+
+	_, err := database.DB.Exec(
+		`UPDATE users
+		 SET full_name = ?, job_title = ?, organization = ?, timezone = ?, bio = ?, role_label = ?
+		 WHERE id = ?`,
+		req.FullName,
+		req.JobTitle,
+		req.Organization,
+		req.Timezone,
+		req.Bio,
+		req.RoleLabel,
+		userID,
+	)
+	if err != nil {
+		http.Error(w, "Failed to update profile", http.StatusInternalServerError)
+		return
+	}
+
+	getProfile(w, r)
 }
 
 func isProductionEnv() bool {

--- a/handlers/auth_test.go
+++ b/handlers/auth_test.go
@@ -28,7 +28,13 @@ func setupTestDB() {
 	CREATE TABLE IF NOT EXISTS users (
 		id INTEGER PRIMARY KEY AUTOINCREMENT,
 		email TEXT NOT NULL UNIQUE,
-		password TEXT NOT NULL
+		password TEXT NOT NULL,
+		full_name TEXT DEFAULT '',
+		job_title TEXT DEFAULT '',
+		organization TEXT DEFAULT '',
+		timezone TEXT DEFAULT '',
+		bio TEXT DEFAULT '',
+		role_label TEXT DEFAULT ''
 	);`
 
 	_, err = database.DB.Exec(createTable)

--- a/main.go
+++ b/main.go
@@ -82,6 +82,7 @@ func main() {
 	mux.Handle("/api/protected", middleware.AuthMiddleware(protectedHandler))
 
 	// Integration routes (protected)
+	mux.Handle("/api/profile", middleware.AuthMiddleware(http.HandlerFunc(handlers.ProfileHandler)))
 	mux.Handle("/api/integrations", middleware.AuthMiddleware(http.HandlerFunc(handlers.GetIntegrations)))
 	mux.Handle("/api/integrations/slack/auth", middleware.AuthMiddleware(http.HandlerFunc(handlers.SlackAuth)))
 	mux.Handle("/api/integrations/slack/channels", middleware.AuthMiddleware(http.HandlerFunc(handlers.GetSlackChannels)))

--- a/middleware/auth.go
+++ b/middleware/auth.go
@@ -83,15 +83,28 @@ func AuthMiddleware(next http.Handler) http.Handler {
 		}
 
 		userID := claims.UserID
-		if userID == 0 && claims.Email != "" && database.DB != nil {
-			err = database.DB.QueryRow("SELECT id FROM users WHERE email = ?", claims.Email).Scan(&userID)
-			if err == sql.ErrNoRows {
-				http.Error(w, "Unauthorized", http.StatusUnauthorized)
-				return
+		if database.DB != nil {
+			if userID != 0 {
+				if err := database.DB.QueryRow("SELECT id FROM users WHERE id = ?", userID).Scan(&userID); err == sql.ErrNoRows {
+					// Recover from stale user IDs in older tokens by falling back to email lookup.
+					userID = 0
+				} else if err != nil {
+					http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+					return
+				}
 			}
-			if err != nil {
-				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-				return
+
+			if userID == 0 && claims.Email != "" {
+				err = database.DB.QueryRow("SELECT id FROM users WHERE email = ?", claims.Email).Scan(&userID)
+				if err == sql.ErrNoRows {
+					if claims.UserID != 0 {
+						http.Error(w, "Unauthorized", http.StatusUnauthorized)
+						return
+					}
+				} else if err != nil {
+					http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+					return
+				}
 			}
 		}
 

--- a/middleware/auth_test.go
+++ b/middleware/auth_test.go
@@ -1,22 +1,31 @@
 package middleware
 
 import (
+	"database/sql"
 	"net/http"
 	"net/http/httptest"
+	"sentinent-backend/database"
 	"sentinent-backend/models"
 	"sentinent-backend/utils"
 	"testing"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
+	_ "github.com/mattn/go-sqlite3"
 )
 
 func makeAuthTestToken(t *testing.T, email string) string {
 	t.Helper()
+	return makeAuthTestTokenWithUserID(t, email, 0)
+}
+
+func makeAuthTestTokenWithUserID(t *testing.T, email string, userID int) string {
+	t.Helper()
 
 	utils.JwtKey = []byte("middleware-test-secret")
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, &models.Claims{
-		Email: email,
+		UserID: userID,
+		Email:  email,
 		RegisteredClaims: jwt.RegisteredClaims{
 			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
 		},
@@ -110,5 +119,58 @@ func TestAuthMiddlewareRejectsMalformedBearerToken(t *testing.T) {
 
 	if rr.Code != http.StatusBadRequest {
 		t.Fatalf("expected status 400, got %d", rr.Code)
+	}
+}
+
+func TestAuthMiddlewareRecoversFromStaleTokenUserID(t *testing.T) {
+	var err error
+	database.DB, err = sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("failed to open in-memory db: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = database.DB.Close()
+		database.DB = nil
+	})
+
+	if _, err := database.DB.Exec(`
+		CREATE TABLE users (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			email TEXT NOT NULL UNIQUE
+		);
+	`); err != nil {
+		t.Fatalf("failed to create users table: %v", err)
+	}
+
+	if _, err := database.DB.Exec("INSERT INTO users (id, email) VALUES (?, ?)", 42, "reader@example.com"); err != nil {
+		t.Fatalf("failed to seed user: %v", err)
+	}
+
+	tokenString := makeAuthTestTokenWithUserID(t, "reader@example.com", 9999)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/protected", nil)
+	req.Header.Set("Authorization", "Bearer "+tokenString)
+	rr := httptest.NewRecorder()
+
+	var gotUserID int
+	var gotEmail string
+	handler := AuthMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		userID, _ := GetUserID(r.Context())
+		email, _ := r.Context().Value(UserEmailKey).(string)
+		gotUserID = userID
+		gotEmail = email
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rr.Code)
+	}
+	if gotUserID != 42 {
+		t.Fatalf("expected resolved user id 42, got %d", gotUserID)
+	}
+	if gotEmail != "reader@example.com" {
+		t.Fatalf("expected email reader@example.com, got %q", gotEmail)
 	}
 }

--- a/middleware/cors.go
+++ b/middleware/cors.go
@@ -66,7 +66,7 @@ func setCORSHeaders(w http.ResponseWriter, origin string) {
 	addVaryHeader(w, "Access-Control-Request-Method")
 	addVaryHeader(w, "Access-Control-Request-Headers")
 	w.Header().Set("Access-Control-Allow-Origin", origin)
-	w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
+	w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
 	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
 	w.Header().Set("Access-Control-Allow-Credentials", "true")
 }

--- a/middleware/cors_test.go
+++ b/middleware/cors_test.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -82,6 +83,9 @@ func TestCorsMiddlewareHandlesAllowedPreflight(t *testing.T) {
 	}
 	if got := rr.Header().Get("Access-Control-Allow-Origin"); got != "http://localhost:4200" {
 		t.Fatalf("expected allowed origin header, got %q", got)
+	}
+	if methods := rr.Header().Get("Access-Control-Allow-Methods"); !strings.Contains(methods, "PATCH") {
+		t.Fatalf("expected PATCH in allow-methods header, got %q", methods)
 	}
 }
 

--- a/models/user.go
+++ b/models/user.go
@@ -1,7 +1,13 @@
 package models
 
 type User struct {
-	ID       int    `json:"id"`
-	Email    string `json:"email"`
-	Password string `json:"password"`
+	ID           int    `json:"id"`
+	Email        string `json:"email"`
+	Password     string `json:"password"`
+	FullName     string `json:"full_name"`
+	JobTitle     string `json:"job_title"`
+	Organization string `json:"organization"`
+	Timezone     string `json:"timezone"`
+	Bio          string `json:"bio"`
+	RoleLabel    string `json:"role_label"`
 }


### PR DESCRIPTION
Refs Sentinent-AI/Sentinent#23

## User Impact
- Signed-in users can load their account profile details from the backend.
- Users can update profile fields (full name, role label, organization, timezone, and bio) and see saved results immediately.
- Profile updates are now fully supported by backend storage and response models.

## Backend Improvements
- added profile GET and PATCH handlers under /api/profile
- expanded users schema and model fields to store profile metadata
- improved auth middleware fallback behavior for stale token user IDs
- updated CORS allow-methods to include PATCH for profile updates
- aligned auth and middleware tests with new behavior

## Validation
- go test ./... (passing)
