### PR TITLE
feat: implement Jira issue sync

### DIFF
--- a/database/db.go
+++ b/database/db.go
@@ -17,6 +17,10 @@ func InitDB() {
 		log.Fatal(err)
 	}
 
+	if _, err := DB.Exec("PRAGMA journal_mode=WAL;"); err != nil {
+		log.Printf("Failed to enable WAL mode: %v", err)
+	}
+
 	statements := []string{
 		`CREATE TABLE IF NOT EXISTS users (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/go.mod
+++ b/go.mod
@@ -10,4 +10,4 @@ require (
 
 require golang.org/x/oauth2 v0.36.0
 
-require github.com/joho/godotenv v1.5.1 // indirect
+require github.com/joho/godotenv v1.5.1

--- a/handlers/jira.go
+++ b/handlers/jira.go
@@ -71,6 +71,7 @@ func validateJiraOAuthState(state string) (string, int, string, error) {
 }
 
 func JiraAuthHandler(w http.ResponseWriter, r *http.Request) {
+	log.Printf("JiraAuthHandler called: %s", r.URL.String())
 	if r.Method != http.MethodGet {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return

--- a/handlers/jira.go
+++ b/handlers/jira.go
@@ -277,7 +277,7 @@ func JiraDisconnectHandler(w http.ResponseWriter, r *http.Request) {
 	_ = json.NewEncoder(w).Encode(map[string]string{"status": "disconnected"})
 }
 
-// JiraProjectsHandler just returns resources as a mock "projects" list or can fetch projects from a cloud id.
+// JiraProjectsHandler returns Jira projects visible to the connected account.
 func JiraProjectsHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
@@ -302,12 +302,12 @@ func JiraProjectsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resources, err := services.FetchAtlassianResources(client)
+	projects, err := services.FetchJiraProjects(client)
 	if err != nil {
-		http.Error(w, "Failed to fetch Atlassian resources: "+err.Error(), http.StatusInternalServerError)
+		http.Error(w, "Failed to fetch Jira projects: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(resources)
+	_ = json.NewEncoder(w).Encode(projects)
 }

--- a/models/signal.go
+++ b/models/signal.go
@@ -3,31 +3,31 @@ package models
 import "time"
 
 const (
-	SourceTypeSlack     = "slack"
-	SourceTypeGitHub    = "github"
-	SourceTypeJira      = "jira"
-	SignalStatusUnread  = "unread"
-	SignalStatusRead    = "read"
+	SourceTypeSlack      = "slack"
+	SourceTypeGitHub     = "github"
+	SourceTypeJira       = "jira"
+	SignalStatusUnread   = "unread"
+	SignalStatusRead     = "read"
 	SignalStatusArchived = "archived"
 )
 
 type Signal struct {
-	ID             int             `json:"id"`
-	UserID         int             `json:"user_id"`
-	WorkspaceID    int             `json:"workspace_id,omitempty"`
-	SourceType     string          `json:"source_type"`
-	SourceID       string          `json:"source_id"`
-	ExternalID     string          `json:"external_id,omitempty"`
-	Title          string          `json:"title"`
-	Content        string          `json:"content,omitempty"`
-	Author         string          `json:"author,omitempty"`
-	Body           string          `json:"body,omitempty"`
-	URL            string          `json:"url,omitempty"`
-	Status         string          `json:"status"`
-	SourceMetadata interface{}     `json:"source_metadata,omitempty"`
-	ReceivedAt     time.Time       `json:"received_at,omitempty"`
-	CreatedAt      time.Time       `json:"created_at"`
-	UpdatedAt      time.Time       `json:"updated_at"`
+	ID             int         `json:"id"`
+	UserID         int         `json:"user_id"`
+	WorkspaceID    int         `json:"workspace_id,omitempty"`
+	SourceType     string      `json:"source_type"`
+	SourceID       string      `json:"source_id"`
+	ExternalID     string      `json:"external_id,omitempty"`
+	Title          string      `json:"title"`
+	Content        string      `json:"content,omitempty"`
+	Author         string      `json:"author,omitempty"`
+	Body           string      `json:"body,omitempty"`
+	URL            string      `json:"url,omitempty"`
+	Status         string      `json:"status"`
+	SourceMetadata interface{} `json:"source_metadata,omitempty"`
+	ReceivedAt     time.Time   `json:"received_at,omitempty"`
+	CreatedAt      time.Time   `json:"created_at"`
+	UpdatedAt      time.Time   `json:"updated_at"`
 }
 
 type GitHubMetadata struct {
@@ -39,12 +39,12 @@ type GitHubMetadata struct {
 }
 
 type JiraMetadata struct {
-	ProjectKey   string `json:"project_key"`
-	IssueType    string `json:"issue_type"`
+	ProjectKey   string `json:"projectKey"`
+	IssueType    string `json:"issueType"`
 	Priority     string `json:"priority,omitempty"`
 	Status       string `json:"status"`
-	IssueKey     string `json:"issue_key"`
-	AssigneeName string `json:"assignee_name,omitempty"`
+	IssueKey     string `json:"issueKey"`
+	AssigneeName string `json:"assigneeName,omitempty"`
 }
 
 type SignalFilter struct {

--- a/services/github.go
+++ b/services/github.go
@@ -33,6 +33,24 @@ func IsGitHubConfigured() bool {
 	return githubOAuthConfig != nil && len(tokenEncryptionKey) > 0
 }
 
+func initTokenEncryptionKey() error {
+	encryptionKey := strings.TrimSpace(os.Getenv("TOKEN_ENCRYPTION_KEY"))
+	if encryptionKey == "" {
+		return fmt.Errorf("TOKEN_ENCRYPTION_KEY must be set")
+	}
+
+	tokenEncryptionKey = []byte(encryptionKey)
+	if len(tokenEncryptionKey) < 32 {
+		paddedKey := make([]byte, 32)
+		copy(paddedKey, tokenEncryptionKey)
+		tokenEncryptionKey = paddedKey
+	} else if len(tokenEncryptionKey) > 32 {
+		tokenEncryptionKey = tokenEncryptionKey[:32]
+	}
+
+	return nil
+}
+
 // GitHubIssue represents a GitHub issue or PR
 // We use a single struct since the API response is similar
 type GitHubIssue struct {
@@ -59,27 +77,13 @@ type GitHubIssue struct {
 func InitGitHubService() error {
 	clientID := strings.TrimSpace(os.Getenv("GITHUB_CLIENT_ID"))
 	clientSecret := strings.TrimSpace(os.Getenv("GITHUB_CLIENT_SECRET"))
-	encryptionKey := strings.TrimSpace(os.Getenv("TOKEN_ENCRYPTION_KEY"))
-
-	if encryptionKey != "" {
-		// Ensure key is 32 bytes for AES-256
-		tokenEncryptionKey = []byte(encryptionKey)
-		if len(tokenEncryptionKey) < 32 {
-			// Pad key to 32 bytes
-			paddedKey := make([]byte, 32)
-			copy(paddedKey, tokenEncryptionKey)
-			tokenEncryptionKey = paddedKey
-		} else if len(tokenEncryptionKey) > 32 {
-			tokenEncryptionKey = tokenEncryptionKey[:32]
-		}
-	}
 
 	if clientID == "" || clientSecret == "" {
 		return fmt.Errorf("GITHUB_CLIENT_ID and GITHUB_CLIENT_SECRET must be set")
 	}
 
-	if encryptionKey == "" {
-		return fmt.Errorf("TOKEN_ENCRYPTION_KEY must be set")
+	if err := initTokenEncryptionKey(); err != nil {
+		return err
 	}
 
 	githubOAuthConfig = &oauth2.Config{
@@ -531,17 +535,37 @@ func GetUserSignals(userID int, filter *models.SignalFilter) ([]models.Signal, e
 		if receivedAt.Valid {
 			signal.ReceivedAt = receivedAt.Time
 		}
-		if metadataJSON.Valid && metadataJSON.String != "" {
-			var metadata models.GitHubMetadata
-			if err := json.Unmarshal([]byte(metadataJSON.String), &metadata); err == nil {
-				signal.SourceMetadata = &metadata
-			}
-		}
+		signal.SourceMetadata = parseSignalMetadata(signal.SourceType, metadataJSON.String)
 
 		signals = append(signals, signal)
 	}
 
 	return signals, rows.Err()
+}
+
+func parseSignalMetadata(sourceType string, metadataJSON string) interface{} {
+	if metadataJSON == "" {
+		return nil
+	}
+
+	switch sourceType {
+	case models.SourceTypeGitHub:
+		var metadata models.GitHubMetadata
+		if err := json.Unmarshal([]byte(metadataJSON), &metadata); err == nil {
+			return &metadata
+		}
+	case models.SourceTypeJira:
+		var metadata models.JiraMetadata
+		if err := json.Unmarshal([]byte(metadataJSON), &metadata); err == nil {
+			return &metadata
+		}
+	}
+
+	var metadata map[string]interface{}
+	if err := json.Unmarshal([]byte(metadataJSON), &metadata); err == nil {
+		return metadata
+	}
+	return nil
 }
 
 // ListAccessibleRepos lists repositories accessible to the user

--- a/services/jira.go
+++ b/services/jira.go
@@ -31,12 +31,23 @@ type AtlassianResource struct {
 	AvatarURL string   `json:"avatarUrl"`
 }
 
+// JiraProject represents a project visible on a Jira Cloud site.
+type JiraProject struct {
+	ID        string `json:"id"`
+	Key       string `json:"key"`
+	Name      string `json:"name"`
+	AvatarURL string `json:"avatarUrl,omitempty"`
+	SiteID    string `json:"siteId"`
+	SiteName  string `json:"siteName"`
+	SiteURL   string `json:"siteUrl"`
+}
+
 // JiraIssue represents an issue retrieved from Jira REST API
 type JiraIssue struct {
 	ID     string `json:"id"`
 	Key    string `json:"key"`
 	Fields struct {
-		Summary     string `json:"summary"`
+		Summary     string      `json:"summary"`
 		Description interface{} `json:"description"`
 		Status      struct {
 			Name string `json:"name"`
@@ -73,6 +84,9 @@ func InitJiraService() error {
 
 	if clientID == "" || clientSecret == "" {
 		return fmt.Errorf("JIRA_CLIENT_ID and JIRA_CLIENT_SECRET must be set")
+	}
+	if err := initTokenEncryptionKey(); err != nil {
+		return err
 	}
 
 	jiraOAuthConfig = &oauth2.Config{
@@ -202,6 +216,10 @@ func DeleteJiraIntegration(userID, workspaceID int) error {
 
 // GetJiraClient creates an HTTP client with the user's Jira token, refreshing if necessary
 func GetJiraClient(userID, workspaceID int) (*http.Client, *oauth2.Token, error) {
+	if jiraOAuthConfig == nil {
+		return nil, nil, fmt.Errorf("Jira OAuth not initialized")
+	}
+
 	integration, err := GetJiraIntegration(userID, workspaceID)
 	if err != nil {
 		return nil, nil, fmt.Errorf("Jira integration not found: %w", err)
@@ -275,50 +293,72 @@ func FetchAtlassianResources(client *http.Client) ([]AtlassianResource, error) {
 // FetchJiraIssues requests issues from a specific Jira cloud site
 func FetchJiraIssues(client *http.Client, cloudId string, jql string) ([]JiraIssue, error) {
 	apiURL := fmt.Sprintf("https://api.atlassian.com/ex/jira/%s/rest/api/3/search/jql", cloudId)
-
-	requestBody, _ := json.Marshal(map[string]interface{}{
-		"jql":        jql,
-		"maxResults": 50,
-		"fields": []string{
-			"summary",
-			"description",
-			"status",
-			"project",
-			"priority",
-			"issuetype",
-			"assignee",
-			"reporter",
-			"updated",
-			"created",
-		},
-	})
-
-	req, err := http.NewRequest("POST", apiURL, bytes.NewBuffer(requestBody))
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Accept", "application/json")
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("Jira API error: %d - %s", resp.StatusCode, string(body))
+	fields := []string{
+		"summary",
+		"description",
+		"status",
+		"project",
+		"priority",
+		"issuetype",
+		"assignee",
+		"reporter",
+		"updated",
+		"created",
 	}
 
-	var result struct {
-		Issues []JiraIssue `json:"issues"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return nil, err
+	issues := make([]JiraIssue, 0)
+	nextPageToken := ""
+	for {
+		requestBody := map[string]interface{}{
+			"jql":        jql,
+			"maxResults": 50,
+			"fields":     fields,
+		}
+		if nextPageToken != "" {
+			requestBody["nextPageToken"] = nextPageToken
+		}
+
+		body, err := json.Marshal(requestBody)
+		if err != nil {
+			return nil, err
+		}
+
+		req, err := http.NewRequest("POST", apiURL, bytes.NewBuffer(body))
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Accept", "application/json")
+
+		resp, err := client.Do(req)
+		if err != nil {
+			return nil, err
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			return nil, fmt.Errorf("Jira API error: %d - %s", resp.StatusCode, string(body))
+		}
+
+		var result struct {
+			Issues        []JiraIssue `json:"issues"`
+			NextPageToken string      `json:"nextPageToken"`
+		}
+		decodeErr := json.NewDecoder(resp.Body).Decode(&result)
+		resp.Body.Close()
+		if decodeErr != nil {
+			return nil, decodeErr
+		}
+
+		issues = append(issues, result.Issues...)
+		if result.NextPageToken == "" {
+			break
+		}
+		nextPageToken = result.NextPageToken
 	}
 
-	return result.Issues, nil
+	return issues, nil
 }
 
 // formatDescription extracts text from Jira ADF (Atlassian Document Format)
@@ -326,20 +366,56 @@ func formatDescription(desc interface{}) string {
 	if desc == nil {
 		return ""
 	}
-	
-	bytes, err := json.Marshal(desc)
+
+	text := strings.TrimSpace(extractADFText(desc))
+	if text != "" {
+		if len(text) > 500 {
+			return text[:500] + "..."
+		}
+		return text
+	}
+
+	body, err := json.Marshal(desc)
 	if err != nil {
 		return ""
 	}
-	
-	// Complex ADF parsing could go here, but for simplicity we'll just store the raw string or attempt basic text extraction
-	// Since ADF is a complex JSON object, returning the raw string or a generic "View issue for description" might be best 
-	// if we don't implement full ADF rendering
-	str := string(bytes)
+	str := string(body)
 	if len(str) > 500 {
 		return str[:500] + "..."
 	}
 	return str
+}
+
+func extractADFText(value interface{}) string {
+	switch typed := value.(type) {
+	case string:
+		return typed
+	case map[string]interface{}:
+		parts := make([]string, 0)
+		if text, ok := typed["text"].(string); ok {
+			parts = append(parts, text)
+		}
+		if content, ok := typed["content"].([]interface{}); ok {
+			for _, child := range content {
+				childText := strings.TrimSpace(extractADFText(child))
+				if childText != "" {
+					parts = append(parts, childText)
+				}
+			}
+		}
+		return strings.Join(parts, " ")
+	case []interface{}:
+		parts := make([]string, 0, len(typed))
+		for _, child := range typed {
+			childText := strings.TrimSpace(extractADFText(child))
+			if childText != "" {
+				parts = append(parts, childText)
+			}
+		}
+		return strings.Join(parts, " ")
+	default:
+		return ""
+	}
 }
 
 func parseJiraDate(dateStr string) time.Time {
@@ -374,7 +450,9 @@ func SyncJiraSignals(userID, workspaceID int) error {
 	}
 
 	for _, issue := range issues {
-		saveJiraIssueAsSignal(userID, workspaceID, issue, cloudURL)
+		if err := saveJiraIssueAsSignal(userID, workspaceID, issue, cloudURL); err != nil {
+			fmt.Printf("Failed to save Jira signal: %v\n", err)
+		}
 	}
 
 	return nil
@@ -385,7 +463,7 @@ func saveJiraIssueAsSignal(userID, workspaceID int, issue JiraIssue, cloudURL st
 	if issue.Fields.Priority != nil {
 		priorityName = issue.Fields.Priority.Name
 	}
-	
+
 	assigneeName := ""
 	if issue.Fields.Assignee != nil {
 		assigneeName = issue.Fields.Assignee.DisplayName
@@ -409,14 +487,7 @@ func saveJiraIssueAsSignal(userID, workspaceID int, issue JiraIssue, cloudURL st
 
 	url := fmt.Sprintf("%s/browse/%s", cloudURL, issue.Key)
 	createdAt := parseJiraDate(issue.Fields.Created)
-	updatedAt := parseJiraDate(issue.Fields.Updated)
 
-	// Since SourceMetadata in models.Signal is strongly typed to GitHubMetadata for now,
-	// we will likely store Jira metadata in a new field or JSON encode it into the body to be generic. 
-	// Wait, the model update we applied added JiraMetadata but didn't modify Signal struct's SourceMetadata type!
-	// We might need to change it to interface{} or add JiraMetadata *JiraMetadata
-	
-	// But let's just save it.
 	_, err := database.DB.Exec(
 		`INSERT INTO signals
 		(user_id, workspace_id, source_type, source_id, external_id, title, content, body, url, author, status, source_metadata, received_at, updated_at)
@@ -425,11 +496,12 @@ func saveJiraIssueAsSignal(userID, workspaceID int, issue JiraIssue, cloudURL st
 		external_id = excluded.external_id,
 		title = excluded.title,
 		content = excluded.content,
+		body = excluded.body,
 		url = excluded.url,
 		author = excluded.author,
-		status = excluded.status,
 		source_metadata = excluded.source_metadata,
-		updated_at = ?`,
+		received_at = excluded.received_at,
+		updated_at = CURRENT_TIMESTAMP`,
 		userID,
 		workspaceID,
 		models.SourceTypeJira,
@@ -437,14 +509,78 @@ func saveJiraIssueAsSignal(userID, workspaceID int, issue JiraIssue, cloudURL st
 		issue.Key,
 		fmt.Sprintf("[%s] %s", issue.Key, issue.Fields.Summary),
 		formatDescription(issue.Fields.Description),
-		"", // body used for different things
+		formatDescription(issue.Fields.Description),
 		url,
 		reporterName,
-		issue.Fields.Status.Name,
+		models.SignalStatusUnread,
 		string(metadataJSON),
 		createdAt, // Setting received_at to creation date or we can use updated_at
-		updatedAt,
 	)
 
 	return err
+}
+
+// FetchJiraProjects returns visible projects across all accessible Jira sites.
+func FetchJiraProjects(client *http.Client) ([]JiraProject, error) {
+	resources, err := FetchAtlassianResources(client)
+	if err != nil {
+		return nil, err
+	}
+
+	projects := make([]JiraProject, 0)
+	for _, resource := range resources {
+		siteProjects, err := fetchJiraProjectsForResource(client, resource)
+		if err != nil {
+			return nil, err
+		}
+		projects = append(projects, siteProjects...)
+	}
+
+	return projects, nil
+}
+
+func fetchJiraProjectsForResource(client *http.Client, resource AtlassianResource) ([]JiraProject, error) {
+	apiURL := fmt.Sprintf("https://api.atlassian.com/ex/jira/%s/rest/api/3/project/search?maxResults=50", resource.ID)
+	req, err := http.NewRequest("GET", apiURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("Jira API error: %d - %s", resp.StatusCode, string(body))
+	}
+
+	var result struct {
+		Values []struct {
+			ID         string            `json:"id"`
+			Key        string            `json:"key"`
+			Name       string            `json:"name"`
+			AvatarURLs map[string]string `json:"avatarUrls"`
+		} `json:"values"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, err
+	}
+
+	projects := make([]JiraProject, 0, len(result.Values))
+	for _, project := range result.Values {
+		projects = append(projects, JiraProject{
+			ID:        project.ID,
+			Key:       project.Key,
+			Name:      project.Name,
+			AvatarURL: project.AvatarURLs["48x48"],
+			SiteID:    resource.ID,
+			SiteName:  resource.Name,
+			SiteURL:   resource.URL,
+		})
+	}
+	return projects, nil
 }

--- a/services/jira_test.go
+++ b/services/jira_test.go
@@ -1,0 +1,221 @@
+package services
+
+import (
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"sentinent-backend/database"
+	"sentinent-backend/models"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func setupJiraTestDB(t *testing.T) func() {
+	t.Helper()
+
+	dbPath := filepath.Join(t.TempDir(), "jira-test.db")
+	db, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		t.Fatalf("failed to open sqlite db: %v", err)
+	}
+
+	statements := []string{
+		`CREATE TABLE signals (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			user_id INTEGER NOT NULL,
+			workspace_id INTEGER,
+			source_type TEXT NOT NULL,
+			source_id TEXT NOT NULL,
+			external_id TEXT,
+			title TEXT NOT NULL,
+			content TEXT,
+			author TEXT,
+			body TEXT,
+			url TEXT,
+			status TEXT DEFAULT 'unread',
+			source_metadata TEXT,
+			received_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+		);`,
+		`CREATE UNIQUE INDEX idx_signals_user_source ON signals(user_id, source_type, source_id);`,
+		`CREATE TABLE signal_status (
+			signal_id INTEGER NOT NULL,
+			user_id INTEGER NOT NULL,
+			status TEXT NOT NULL,
+			updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			PRIMARY KEY (signal_id, user_id)
+		);`,
+	}
+	for _, statement := range statements {
+		if _, err := db.Exec(statement); err != nil {
+			t.Fatalf("failed to prepare jira test schema: %v", err)
+		}
+	}
+
+	originalDB := database.DB
+	database.DB = db
+	return func() {
+		database.DB = originalDB
+		_ = db.Close()
+	}
+}
+
+func TestFormatDescriptionExtractsADFText(t *testing.T) {
+	description := map[string]interface{}{
+		"type": "doc",
+		"content": []interface{}{
+			map[string]interface{}{
+				"type": "paragraph",
+				"content": []interface{}{
+					map[string]interface{}{"type": "text", "text": "Fix dashboard"},
+					map[string]interface{}{"type": "text", "text": "filters"},
+				},
+			},
+		},
+	}
+
+	got := formatDescription(description)
+	if got != "Fix dashboard filters" {
+		t.Fatalf("expected ADF text extraction, got %q", got)
+	}
+}
+
+func TestSaveJiraIssueAsSignalStoresUnreadSignalWithMetadata(t *testing.T) {
+	cleanup := setupJiraTestDB(t)
+	defer cleanup()
+
+	issue := JiraIssue{
+		ID:  "10001",
+		Key: "SEN-17",
+	}
+	issue.Fields.Summary = "Investigate sync failure"
+	issue.Fields.Description = map[string]interface{}{
+		"content": []interface{}{
+			map[string]interface{}{"content": []interface{}{
+				map[string]interface{}{"text": "Webhook delivery failed"},
+			}},
+		},
+	}
+	issue.Fields.Status.Name = "In Progress"
+	issue.Fields.Project.Key = "SEN"
+	issue.Fields.Project.Name = "Sentinent"
+	issue.Fields.Issuetype.Name = "Bug"
+	issue.Fields.Priority = &struct {
+		Name string `json:"name"`
+	}{Name: "High"}
+	issue.Fields.Assignee = &struct {
+		DisplayName string `json:"displayName"`
+	}{DisplayName: "Yash"}
+	issue.Fields.Reporter = &struct {
+		DisplayName string `json:"displayName"`
+	}{DisplayName: "Reporter"}
+	issue.Fields.Created = "2026-04-27T12:30:00.000-0400"
+
+	if err := saveJiraIssueAsSignal(1, 7, issue, "https://sentinent.atlassian.net"); err != nil {
+		t.Fatalf("failed to save jira signal: %v", err)
+	}
+
+	signals, err := GetUserSignals(1, &models.SignalFilter{SourceType: models.SourceTypeJira})
+	if err != nil {
+		t.Fatalf("failed to load signals: %v", err)
+	}
+	if len(signals) != 1 {
+		t.Fatalf("expected one signal, got %d", len(signals))
+	}
+
+	signal := signals[0]
+	if signal.Status != models.SignalStatusUnread {
+		t.Fatalf("expected signal status unread, got %q", signal.Status)
+	}
+	if signal.Title != "[SEN-17] Investigate sync failure" {
+		t.Fatalf("unexpected title %q", signal.Title)
+	}
+	if signal.Content != "Webhook delivery failed" {
+		t.Fatalf("unexpected content %q", signal.Content)
+	}
+	if signal.URL != "https://sentinent.atlassian.net/browse/SEN-17" {
+		t.Fatalf("unexpected Jira URL %q", signal.URL)
+	}
+
+	metadata, ok := signal.SourceMetadata.(*models.JiraMetadata)
+	if !ok {
+		t.Fatalf("expected Jira metadata, got %#v", signal.SourceMetadata)
+	}
+	if metadata.ProjectKey != "SEN" || metadata.IssueType != "Bug" || metadata.Priority != "High" {
+		t.Fatalf("unexpected Jira metadata: %+v", metadata)
+	}
+	if metadata.Status != "In Progress" || metadata.IssueKey != "SEN-17" || metadata.AssigneeName != "Yash" {
+		t.Fatalf("unexpected Jira issue details: %+v", metadata)
+	}
+}
+
+func TestFetchJiraIssuesUsesSearchJQLPagination(t *testing.T) {
+	originalDefaultTransport := http.DefaultTransport
+	originalDefaultClientTransport := http.DefaultClient.Transport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalDefaultTransport
+		http.DefaultClient.Transport = originalDefaultClientTransport
+	})
+
+	requests := 0
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/ex/jira/cloud-123/rest/api/3/search/jql" {
+			t.Fatalf("unexpected Jira API path: %s", r.URL.Path)
+		}
+
+		var payload map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		requests++
+
+		switch requests {
+		case 1:
+			if _, ok := payload["nextPageToken"]; ok {
+				t.Fatal("first request should not include nextPageToken")
+			}
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"issues":        []JiraIssue{{ID: "1", Key: "SEN-1"}},
+				"nextPageToken": "page-2",
+			})
+		case 2:
+			if payload["nextPageToken"] != "page-2" {
+				t.Fatalf("expected nextPageToken page-2, got %#v", payload["nextPageToken"])
+			}
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"issues": []JiraIssue{{ID: "2", Key: "SEN-2"}},
+			})
+		default:
+			t.Fatalf("unexpected extra request %d", requests)
+		}
+	}))
+	defer server.Close()
+
+	targetURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("failed to parse server URL: %v", err)
+	}
+	rewriteTransport := githubRewriteTransport{
+		base:   server.Client().Transport,
+		target: targetURL,
+	}
+	client := &http.Client{Transport: rewriteTransport}
+	http.DefaultTransport = rewriteTransport
+	http.DefaultClient.Transport = rewriteTransport
+
+	issues, err := FetchJiraIssues(client, "cloud-123", "assignee = currentUser()")
+	if err != nil {
+		t.Fatalf("FetchJiraIssues returned error: %v", err)
+	}
+	if len(issues) != 2 {
+		t.Fatalf("expected 2 issues, got %d", len(issues))
+	}
+	if issues[0].Key != "SEN-1" || issues[1].Key != "SEN-2" {
+		t.Fatalf("unexpected issues: %+v", issues)
+	}
+}

--- a/services/sync.go
+++ b/services/sync.go
@@ -108,16 +108,22 @@ func (s *SyncService) syncAllIntegrations() {
 	}
 
 	for _, record := range records {
-		// Decrypt token
-		accessToken, err := s.tokenEncryptor.Decrypt(record.encryptedToken)
-		if err != nil {
-			log.Printf("Failed to decrypt token for integration %d: %v", record.integration.ID, err)
-			continue
-		}
-
 		switch record.integration.Provider {
 		case "slack":
+			accessToken, err := s.tokenEncryptor.Decrypt(record.encryptedToken)
+			if err != nil {
+				log.Printf("Failed to decrypt token for integration %d: %v", record.integration.ID, err)
+				continue
+			}
 			s.syncSlackIntegration(&record.integration, accessToken)
+		case "github":
+			if err := SyncGitHubSignals(record.integration.UserID, record.integration.WorkspaceID); err != nil {
+				log.Printf("Failed to sync GitHub integration %d: %v", record.integration.ID, err)
+			}
+		case "jira":
+			if err := SyncJiraSignals(record.integration.UserID, record.integration.WorkspaceID); err != nil {
+				log.Printf("Failed to sync Jira integration %d: %v", record.integration.ID, err)
+			}
 		default:
 			log.Printf("Unknown provider: %s", record.integration.Provider)
 		}


### PR DESCRIPTION
Closes Sentinent-AI/Sentinent#29.

## Changes
- Add Jira OAuth token setup and workspace-scoped issue syncing.
- Fetch accessible Jira projects and paginated JQL issue results.
- Persist Jira issues as unread Sentinent signals with typed metadata.
- Include Jira in background integration sync.
- Add service tests for Jira description parsing, signal persistence, and JQL pagination.
- **Enable WAL mode in SQLite** to prevent database locks from hanging requests.
- **Add debug logging** to the Jira authentication handler.

## Tests
- `env GOCACHE=/Users/yashrastogi/Documents/Sentinent/backend-go/.gocache GOMODCACHE=/Users/yashrastogi/Documents/Sentinent/backend-go/.gomodcache go test ./...`