### PR TITLE
fix(github): update source_metadata state field instead of signals.status

### DIFF
--- a/services/github.go
+++ b/services/github.go
@@ -733,10 +733,24 @@ func UpdateGitHubIssueState(userID, workspaceID int, repo string, number int, st
 		return fmt.Errorf("GitHub API error: %d - %s", resp.StatusCode, string(respBody))
 	}
 
-	// Update local signal state if it exists
+	// Update the state field inside source_metadata for the matching signal.
+	// The previous state is the opposite of the new one.
+	oldState := "closed"
+	if state == "closed" {
+		oldState = "open"
+	}
 	_, _ = database.DB.Exec(
-		`UPDATE signals SET status = ? WHERE user_id = ? AND workspace_id = ? AND source_type = 'github' AND source_metadata LIKE ?`,
-		state, userID, workspaceID, fmt.Sprintf("%%\"number\":%d%%", number),
+		`UPDATE signals
+		 SET source_metadata = replace(source_metadata, ?, ?),
+		     updated_at      = CURRENT_TIMESTAMP
+		 WHERE user_id       = ?
+		   AND workspace_id  = ?
+		   AND source_type   = 'github'
+		   AND source_metadata LIKE ?`,
+		fmt.Sprintf(`"state":"%s"`, oldState),
+		fmt.Sprintf(`"state":"%s"`, state),
+		userID, workspaceID,
+		fmt.Sprintf(`%%"number":%d%%`, number),
 	)
 
 	return nil


### PR DESCRIPTION
## Summary

Fixes the "close issue from dashboard" bug (Sentinent-AI/Sentinent#35).

## Problem

`UpdateGitHubIssueState` was writing `'open'` / `'closed'` into the `signals.status` column, which is reserved for the read/unread/archived workflow state. This meant the toggle call appeared to succeed (200 from GitHub API) but the local signal record was never updated correctly, so the card state didn't change on refresh.

## Fix

Instead of updating `signals.status`, the handler now updates the `"state"` key inside the `source_metadata` JSON using SQLite's `replace()` function, scoped to the matching signal by `user_id`, `workspace_id`, `source_type = 'github'`, and the issue number pattern in the metadata.

```sql
UPDATE signals
SET source_metadata = replace(source_metadata, '"state":"open"', '"state":"closed"'),
    updated_at      = CURRENT_TIMESTAMP
WHERE user_id      = ?
  AND workspace_id = ?
  AND source_type  = 'github'
  AND source_metadata LIKE '%"number":123%'
```

## Files changed
- `services/github.go`