### PR TITLE
feat(invitations): invitation emails, SMTP hardening, resend endpoint, expose invited email (closes Sentinent-AI/Sentinent#31)

### DIFF
--- a/handlers/invitations.go
+++ b/handlers/invitations.go
@@ -5,10 +5,14 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
+	"log"
 	"net/http"
+	"os"
 	"sentinent-backend/database"
 	"sentinent-backend/middleware"
 	"sentinent-backend/models"
+	"sentinent-backend/services"
 	"sentinent-backend/utils"
 	"strconv"
 	"strings"
@@ -113,6 +117,31 @@ func CreateInvitation(w http.ResponseWriter, r *http.Request) {
 	}
 
 	invitationID, _ := result.LastInsertId()
+
+	// Send invitation email — look up workspace name and inviter email for the message body.
+	go func() {
+		var workspaceName string
+		if err := database.DB.QueryRow("SELECT name FROM workspaces WHERE id = ?", workspaceID).Scan(&workspaceName); err != nil {
+			log.Printf("invitation email: could not fetch workspace name for workspace %d: %v", workspaceID, err)
+			return
+		}
+		var inviterEmail string
+		if err := database.DB.QueryRow("SELECT email FROM users WHERE id = ?", userID).Scan(&inviterEmail); err != nil {
+			log.Printf("invitation email: could not fetch inviter email for user %d: %v", userID, err)
+			return
+		}
+		baseURL := strings.TrimRight(strings.TrimSpace(os.Getenv("FRONTEND_BASE_URL")), "/")
+		if baseURL == "" {
+			baseURL = "http://localhost:4200"
+		}
+		acceptURL := fmt.Sprintf("%s/invitations/%s", baseURL, token)
+		if err := services.SendInvitationEmail(req.Email, workspaceName, inviterEmail, acceptURL); err != nil {
+			log.Printf("invitation email: failed to send to %s: %v", req.Email, err)
+		} else {
+			log.Printf("invitation email: sent to %s for workspace %d", req.Email, workspaceID)
+		}
+	}()
+
 	response := models.InvitationResponse{
 		ID:          int(invitationID),
 		WorkspaceID: workspaceID,

--- a/handlers/invitations.go
+++ b/handlers/invitations.go
@@ -192,11 +192,11 @@ func ListInvitations(w http.ResponseWriter, r *http.Request) {
 	}
 
 	rows, err := database.DB.Query(
-		`SELECT id, workspace_id, email, token, role, expires_at, created_by, created_at, updated_at
+		`SELECT id, workspace_id, email, token, role, expires_at, created_by, created_at, updated_at, accepted_at
 		 FROM invitations
-		 WHERE workspace_id = ? AND accepted_at IS NULL AND expires_at > ?
+		 WHERE workspace_id = ?
 		 ORDER BY created_at DESC`,
-		workspaceID, time.Now(),
+		workspaceID,
 	)
 	if err != nil {
 		http.Error(w, "Failed to fetch invitations", http.StatusInternalServerError)
@@ -217,6 +217,7 @@ func ListInvitations(w http.ResponseWriter, r *http.Request) {
 			&invitation.CreatedBy,
 			&invitation.CreatedAt,
 			&invitation.UpdatedAt,
+			&invitation.AcceptedAt,
 		); err != nil {
 			http.Error(w, "Failed to scan invitation", http.StatusInternalServerError)
 			return
@@ -434,6 +435,82 @@ func CancelInvitation(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusNoContent)
+}
+
+
+func ResendInvitation(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	userID, ok := middleware.GetUserID(r.Context())
+	if !ok {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	// Path: /api/invitations/:token/resend  -> parts[2] = token
+	parts := splitPath(r.URL.Path)
+	if len(parts) < 3 {
+		http.Error(w, "Invalid path", http.StatusBadRequest)
+		return
+	}
+	token := parts[2]
+
+	var invitation models.Invitation
+	var createdBy int
+	err := database.DB.QueryRow(
+		`SELECT id, workspace_id, email, role, expires_at, created_by
+		 FROM invitations
+		 WHERE token = ? AND accepted_at IS NULL`,
+		token,
+	).Scan(&invitation.ID, &invitation.WorkspaceID, &invitation.Email, &invitation.Role, &invitation.ExpiresAt, &createdBy)
+	if err != nil {
+		http.Error(w, "Invalid or already accepted invitation", http.StatusNotFound)
+		return
+	}
+	if time.Now().After(invitation.ExpiresAt) {
+		http.Error(w, "Invitation has expired", http.StatusGone)
+		return
+	}
+
+	isOwner, err := middleware.IsWorkspaceOwner(userID, invitation.WorkspaceID)
+	if err != nil || !isOwner {
+		http.Error(w, "Forbidden: Only owners can resend invitations", http.StatusForbidden)
+		return
+	}
+
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				log.Printf("resend invitation email: goroutine panic (recovered): %v", r)
+			}
+		}()
+		var workspaceName string
+		if err := database.DB.QueryRow("SELECT name FROM workspaces WHERE id = ?", invitation.WorkspaceID).Scan(&workspaceName); err != nil {
+			log.Printf("resend invitation email: could not fetch workspace name: %v", err)
+			return
+		}
+		var inviterEmail string
+		if err := database.DB.QueryRow("SELECT email FROM users WHERE id = ?", userID).Scan(&inviterEmail); err != nil {
+			log.Printf("resend invitation email: could not fetch inviter email: %v", err)
+			return
+		}
+		baseURL := strings.TrimRight(strings.TrimSpace(os.Getenv("FRONTEND_BASE_URL")), "/")
+		if baseURL == "" {
+			baseURL = "http://localhost:4200"
+		}
+		acceptURL := fmt.Sprintf("%s/invitations/%s", baseURL, token)
+		if err := services.SendInvitationEmail(invitation.Email, workspaceName, inviterEmail, acceptURL); err != nil {
+			log.Printf("resend invitation email: failed to send to %s: %v", invitation.Email, err)
+		} else {
+			log.Printf("resend invitation email: sent to %s for workspace %d", invitation.Email, invitation.WorkspaceID)
+		}
+	}()
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]string{"status": "sent"})
 }
 
 func generateSecureToken() (string, error) {

--- a/handlers/invitations.go
+++ b/handlers/invitations.go
@@ -120,6 +120,12 @@ func CreateInvitation(w http.ResponseWriter, r *http.Request) {
 
 	// Send invitation email — look up workspace name and inviter email for the message body.
 	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				log.Printf("invitation email: goroutine panic (recovered): %v", r)
+			}
+		}()
+
 		var workspaceName string
 		if err := database.DB.QueryRow("SELECT name FROM workspaces WHERE id = ?", workspaceID).Scan(&workspaceName); err != nil {
 			log.Printf("invitation email: could not fetch workspace name for workspace %d: %v", workspaceID, err)

--- a/handlers/invitations.go
+++ b/handlers/invitations.go
@@ -280,6 +280,7 @@ func ValidateInvitation(w http.ResponseWriter, r *http.Request) {
 
 	response := map[string]interface{}{
 		"valid": true,
+		"email": invitation.Email,
 		"workspace": map[string]interface{}{
 			"id":   invitation.WorkspaceID,
 			"name": workspaceName,

--- a/main.go
+++ b/main.go
@@ -139,6 +139,8 @@ func main() {
 			middleware.AuthMiddleware(http.HandlerFunc(handlers.CancelInvitation)).ServeHTTP(w, r)
 		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/accept"):
 			middleware.AuthMiddleware(http.HandlerFunc(handlers.AcceptInvitation)).ServeHTTP(w, r)
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/resend"):
+			middleware.AuthMiddleware(http.HandlerFunc(handlers.ResendInvitation)).ServeHTTP(w, r)
 		default:
 			http.Error(w, "Not found", http.StatusNotFound)
 		}

--- a/services/mailer.go
+++ b/services/mailer.go
@@ -49,6 +49,47 @@ func PasswordResetEmailDeliveryConfigured() bool {
 	return err == nil
 }
 
+func SendInvitationEmail(toEmail, workspaceName, invitedByEmail, acceptURL string) error {
+	config, err := LoadSMTPConfigFromEnv()
+	if err != nil {
+		return err
+	}
+
+	subject := fmt.Sprintf("You've been invited to join %s on Sentinent", workspaceName)
+	body := fmt.Sprintf(
+		"Hello,\r\n\r\n%s has invited you to join the workspace \"%s\" on Sentinent.\r\n\r\nAccept your invitation here:\r\n%s\r\n\r\nThis invitation expires in 7 days. If you weren't expecting this, you can safely ignore this email.\r\n",
+		invitedByEmail, workspaceName, acceptURL,
+	)
+
+	fromHeader := config.FromEmail
+	if config.FromName != "" {
+		fromHeader = (&mail.Address{Name: config.FromName, Address: config.FromEmail}).String()
+	}
+
+	message := strings.Join([]string{
+		"From: " + fromHeader,
+		"To: " + toEmail,
+		"Subject: " + subject,
+		"MIME-Version: 1.0",
+		"Content-Type: text/plain; charset=UTF-8",
+		"",
+		body,
+	}, "\r\n")
+
+	var auth smtp.Auth
+	if config.Username != "" || config.Password != "" {
+		auth = smtp.PlainAuth("", config.Username, config.Password, config.Host)
+	}
+
+	return smtp.SendMail(
+		fmt.Sprintf("%s:%d", config.Host, config.Port),
+		auth,
+		config.FromEmail,
+		[]string{toEmail},
+		[]byte(message),
+	)
+}
+
 func SendPasswordResetEmail(toEmail, resetURL string) error {
 	config, err := LoadSMTPConfigFromEnv()
 	if err != nil {

--- a/services/mailer.go
+++ b/services/mailer.go
@@ -1,16 +1,21 @@
 package services
 
 import (
+	"crypto/tls"
 	"errors"
 	"fmt"
+	"net"
 	"net/mail"
 	"net/smtp"
 	"os"
 	"strconv"
 	"strings"
+	"time"
 )
 
 var ErrSMTPNotConfigured = errors.New("smtp configuration is incomplete")
+
+const smtpTimeout = 15 * time.Second
 
 type SMTPConfig struct {
 	Host      string
@@ -49,6 +54,82 @@ func PasswordResetEmailDeliveryConfigured() bool {
 	return err == nil
 }
 
+// sendSMTP dials the SMTP server with a hard 15-second timeout for both the
+// TCP connection and the entire SMTP conversation. This prevents the caller
+// from blocking indefinitely when a firewall silently drops the connection.
+func sendSMTP(config SMTPConfig, message string, recipients []string) error {
+	addr := fmt.Sprintf("%s:%d", config.Host, config.Port)
+
+	// Dial with explicit timeout so we fail fast instead of waiting minutes.
+	conn, err := net.DialTimeout("tcp", addr, smtpTimeout)
+	if err != nil {
+		return fmt.Errorf("smtp dial %s: %w", addr, err)
+	}
+	// Apply a deadline to every subsequent read/write on this connection.
+	conn.SetDeadline(time.Now().Add(smtpTimeout)) //nolint:errcheck
+	defer conn.Close()
+
+	c, err := smtp.NewClient(conn, config.Host)
+	if err != nil {
+		return fmt.Errorf("smtp client: %w", err)
+	}
+	defer c.Close()
+
+	// Upgrade to TLS via STARTTLS if the server advertises it (port 587).
+	if ok, _ := c.Extension("STARTTLS"); ok {
+		if err = c.StartTLS(&tls.Config{ServerName: config.Host}); err != nil {
+			return fmt.Errorf("smtp starttls: %w", err)
+		}
+	}
+
+	// Authenticate when credentials are provided.
+	if config.Username != "" || config.Password != "" {
+		auth := smtp.PlainAuth("", config.Username, config.Password, config.Host)
+		if err = c.Auth(auth); err != nil {
+			return fmt.Errorf("smtp auth: %w", err)
+		}
+	}
+
+	if err = c.Mail(config.FromEmail); err != nil {
+		return fmt.Errorf("smtp MAIL FROM: %w", err)
+	}
+	for _, to := range recipients {
+		if err = c.Rcpt(to); err != nil {
+			return fmt.Errorf("smtp RCPT TO <%s>: %w", to, err)
+		}
+	}
+
+	wc, err := c.Data()
+	if err != nil {
+		return fmt.Errorf("smtp DATA: %w", err)
+	}
+	if _, err = wc.Write([]byte(message)); err != nil {
+		wc.Close()
+		return fmt.Errorf("smtp write body: %w", err)
+	}
+	if err = wc.Close(); err != nil {
+		return fmt.Errorf("smtp close data writer: %w", err)
+	}
+	return c.Quit()
+}
+
+// buildMessage creates the raw SMTP message bytes from config and body.
+func buildMessage(config SMTPConfig, toEmail, subject, body string) string {
+	fromHeader := config.FromEmail
+	if config.FromName != "" {
+		fromHeader = (&mail.Address{Name: config.FromName, Address: config.FromEmail}).String()
+	}
+	return strings.Join([]string{
+		"From: " + fromHeader,
+		"To: " + toEmail,
+		"Subject: " + subject,
+		"MIME-Version: 1.0",
+		"Content-Type: text/plain; charset=UTF-8",
+		"",
+		body,
+	}, "\r\n")
+}
+
 func SendInvitationEmail(toEmail, workspaceName, invitedByEmail, acceptURL string) error {
 	config, err := LoadSMTPConfigFromEnv()
 	if err != nil {
@@ -61,33 +142,7 @@ func SendInvitationEmail(toEmail, workspaceName, invitedByEmail, acceptURL strin
 		invitedByEmail, workspaceName, acceptURL,
 	)
 
-	fromHeader := config.FromEmail
-	if config.FromName != "" {
-		fromHeader = (&mail.Address{Name: config.FromName, Address: config.FromEmail}).String()
-	}
-
-	message := strings.Join([]string{
-		"From: " + fromHeader,
-		"To: " + toEmail,
-		"Subject: " + subject,
-		"MIME-Version: 1.0",
-		"Content-Type: text/plain; charset=UTF-8",
-		"",
-		body,
-	}, "\r\n")
-
-	var auth smtp.Auth
-	if config.Username != "" || config.Password != "" {
-		auth = smtp.PlainAuth("", config.Username, config.Password, config.Host)
-	}
-
-	return smtp.SendMail(
-		fmt.Sprintf("%s:%d", config.Host, config.Port),
-		auth,
-		config.FromEmail,
-		[]string{toEmail},
-		[]byte(message),
-	)
+	return sendSMTP(config, buildMessage(config, toEmail, subject, body), []string{toEmail})
 }
 
 func SendPasswordResetEmail(toEmail, resetURL string) error {
@@ -102,31 +157,5 @@ func SendPasswordResetEmail(toEmail, resetURL string) error {
 		resetURL,
 	)
 
-	fromHeader := config.FromEmail
-	if config.FromName != "" {
-		fromHeader = (&mail.Address{Name: config.FromName, Address: config.FromEmail}).String()
-	}
-
-	message := strings.Join([]string{
-		"From: " + fromHeader,
-		"To: " + toEmail,
-		"Subject: " + subject,
-		"MIME-Version: 1.0",
-		"Content-Type: text/plain; charset=UTF-8",
-		"",
-		body,
-	}, "\r\n")
-
-	var auth smtp.Auth
-	if config.Username != "" || config.Password != "" {
-		auth = smtp.PlainAuth("", config.Username, config.Password, config.Host)
-	}
-
-	return smtp.SendMail(
-		fmt.Sprintf("%s:%d", config.Host, config.Port),
-		auth,
-		config.FromEmail,
-		[]string{toEmail},
-		[]byte(message),
-	)
+	return sendSMTP(config, buildMessage(config, toEmail, subject, body), []string{toEmail})
 }


### PR DESCRIPTION
Closes Sentinent-AI/Sentinent#31

## What changed
- `feat(invitations)`: send invitation email on `CreateInvitation` in a safe goroutine with `defer recover()`
- `fix(mailer)`: custom TCP dialer with 15s dial + transaction timeout — replaces bare `smtp.SendMail` that could block indefinitely
- `feat(invitations)`: expose `email` field in `GET /api/invitations/:token` response so frontend can detect wrong-account logins
- `feat(invitations)`: `POST /api/invitations/:token/resend` — re-sends the invitation email for an existing unaccepted token; owner-only
- `fix(invitations)`: `ListInvitations` now returns both pending and accepted invitations with `accepted_at` included